### PR TITLE
fix: add declaration of necessary flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,11 +44,11 @@ func lock() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lock",
 		Short: "Create a lock",
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			LockTimeout := viper.GetInt(LockTimeoutVar)
-			LockTable := viper.GetString(LockTableVar)
-			LockKeyName := viper.GetString(LockKeyNameVar)
-			LockName := viper.GetString(LockNameVar)
+			LockTable, _ := cmd.Flags().GetString(LockTableVar)
+			LockKeyName, _ := cmd.Flags().GetString(LockKeyNameVar)
+			LockName, _ := cmd.Flags().GetString(LockNameVar)
 
 			log.Print("Creating lock with the following parameters:")
 			log.Printf("LockTimeout: %v", LockTimeout)
@@ -104,7 +104,6 @@ func lock() *cobra.Command {
 
 	cmd.PersistentFlags().String(LockNameVar, DefaultLockName, "Name of the lock")
 	viper.BindPFlag(LockNameVar, cmd.PersistentFlags().Lookup(LockNameVar))
-
 	return cmd
 }
 
@@ -112,10 +111,10 @@ func unlock() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unlock",
 		Short: "Release a lock",
-		Run: func(_ *cobra.Command, _ []string) {
-			LockTable := viper.GetString(LockTableVar)
-			LockKeyName := viper.GetString(LockKeyNameVar)
-			LockName := viper.GetString(LockNameVar)
+		Run: func(cmd *cobra.Command, _ []string) {
+			LockTable, _ := cmd.Flags().GetString(LockTableVar)
+			LockKeyName, _ := cmd.Flags().GetString(LockKeyNameVar)
+			LockName, _ := cmd.Flags().GetString(LockNameVar)
 
 			svc := dynamodb.New(session.Must(session.NewSession()))
 
@@ -171,6 +170,9 @@ func main() {
 	viper.SetEnvPrefix("INPUT")
 	viper.AutomaticEnv()
 
+	rootCmd.Flags().String(LockTableVar, "", "DynamoDB table to write the lock in")
+	rootCmd.Flags().String(LockKeyNameVar, "", "Name of the column where we write locks")
+	rootCmd.Flags().String(LockNameVar, "", "Name of the lock")
 	rootCmd.AddCommand(lock())
 	rootCmd.AddCommand(unlock())
 	rootCmd.Execute()


### PR DESCRIPTION
Hello,

Using the binary generated with go I realized that it was not taking the value of the arguments.

An example of execution with the original code would be the following:
```
./github-action-locks lock --timeout "60" --table "github_action_locks_test" --key "LockID" --name "my-apps"
2022/07/20 12:26:38 Creating lock with the following parameters:
2022/07/20 12:26:38 LockTimeout: 60
2022/07/20 12:26:38 LockTable: github-action-locks
2022/07/20 12:26:38 LockKeyName: LockID
2022/07/20 12:26:38 LockName: foobar
2022/07/20 12:26:38 Acquiring lo
```

After performing several tests and debugging in the code I realized that the problem was related to not declaring the cobra flags.

The result after the changes with the same input parameters as in the example above is as follows:
```
./github-action-locks lock --timeout "60" --table "github_action_locks_test" --key "LockID" --name "my-apps"
2022/07/20 12:27:58 Creating lock with the following parameters:
2022/07/20 12:27:58 LockTimeout: 60
2022/07/20 12:27:58 LockTable: github_action_locks_test
2022/07/20 12:27:58 LockKeyName: LockID
2022/07/20 12:27:58 LockName: my-apps
2022/07/20 12:27:58 Acquiring lock
```